### PR TITLE
Add Ubuntu 22.04 specs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,18 +197,18 @@ If you verify any of these states, please open a pull request updating the follo
 | fingerprint-reader           | yes          | yes          |                                                                      |
 | framework-sec-trim-enable    | yes          | yes          |                                                                      |
 | grub-decrease-menu-timeout   | yes          | yes          |                                                                      |
-| hibernate                    | yes          |              | [yes](https://github.com/lightrush/framework-laptop-formula/pull/12) |
+| hibernate                    | yes          | yes          | [yes](https://github.com/lightrush/framework-laptop-formula/pull/12) |
 | intel-audio-workaround       | yes          | yes          |                                                                      |
 | intel-ax210-workaround       | yes          | yes          |                                                                      |
 | intel-xe-tearing-workaround  |              | yes          |                                                                      |
 | mem-sleep-default            | yes          | yes          |                                                                      |
-| mouse-accel-profile          | yes          |              |                                                                      |
+| mouse-accel-profile          | yes          | yes          |                                                                      |
 | tlp                          | yes          | yes          |                                                                      |
-| touchpad-click-method        | yes          |              |                                                                      |
+| touchpad-click-method        | yes          | yes          |                                                                      |
 | touchpad-suspend-workaround  | yes          | yes          |                                                                      |
 | post-resume-power-draw       |              | yes          |                                                                      |
 | pulseaudio-bt-hires-codecs   |              | yes          |                                                                      |
-| vmware-graphics-acceleration | yes          |              |                                                                      |
+| vmware-graphics-acceleration | yes          | yes          |                                                                      |
 
 ### How do I use this?
 

--- a/README.md
+++ b/README.md
@@ -189,22 +189,26 @@ Yes. The changes will persist.
 
 This was tested on the Framework with both the i5 and i7 CPUs, with non-vPro wifi modules.
 The following table describes the available states, and which distributions they have been tested with.
-If you're using it on something else, it may or may not work, use your own discretion. If you verify any of these states, please open a pull request updating the following table.
+If you're using it on something else, it may or may not work, use your own discretion.
+If you verify any of these states, please open a pull request updating the following table.
 
-|                             | Ubuntu 20.04 | Manjaro 21.1.6                                                       |
-|-----------------------------|:------------:|:--------------------------------------------------------------------:|
-| fingerprint-reader          | yes          |                                                                      |
-| framework-sec-trim-enable   | yes          |                                                                      |
-| grub-decrease-menu-timeout  | yes          |                                                                      |
-| hibernate                   | yes          | [yes](https://github.com/lightrush/framework-laptop-formula/pull/12) |
-| intel-audio-workaround      | yes          |                                                                      |
-| intel-ax210-workaround      | yes          |                                                                      |
-| mem-sleep-default           | yes          |                                                                      |
-| mouse-accel-profile         | yes          |                                                                      |
-| tlp                         | yes          |                                                                      |
-| touchpad-click-method       | yes          |                                                                      |
-| touchpad-suspend-workaround | yes          |                                                                      |
-| vmware-graphics-acceleration | yes          |                                                                      |
+|                              | Ubuntu 20.04 | Ubuntu 22.04 | Manjaro 21.1.6                                                       |
+|------------------------------|:------------:|:------------:|:--------------------------------------------------------------------:|
+| fingerprint-reader           | yes          | yes          |                                                                      |
+| framework-sec-trim-enable    | yes          | yes          |                                                                      |
+| grub-decrease-menu-timeout   | yes          | yes          |                                                                      |
+| hibernate                    | yes          | yes          | [yes](https://github.com/lightrush/framework-laptop-formula/pull/12) |
+| intel-audio-workaround       | yes          | yes          |                                                                      |
+| intel-ax210-workaround       | yes          | yes          |                                                                      |
+| intel-xe-tearing-workaround  |              | yes          |                                                                      |
+| mem-sleep-default            | yes          | yes          |                                                                      |
+| mouse-accel-profile          | yes          |              |                                                                      |
+| tlp                          | yes          | yes          |                                                                      |
+| touchpad-click-method        | yes          |              |                                                                      |
+| touchpad-suspend-workaround  | yes          | yes          |                                                                      |
+| post-resume-power-draw       |              | yes          |                                                                      |
+| pulseaudio-bt-hires-codecs   |              | yes          |                                                                      |
+| vmware-graphics-acceleration | yes          |              |                                                                      |
 
 ### How do I use this?
 

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ If you verify any of these states, please open a pull request updating the follo
 | fingerprint-reader           | yes          | yes          |                                                                      |
 | framework-sec-trim-enable    | yes          | yes          |                                                                      |
 | grub-decrease-menu-timeout   | yes          | yes          |                                                                      |
-| hibernate                    | yes          | yes          | [yes](https://github.com/lightrush/framework-laptop-formula/pull/12) |
+| hibernate                    | yes          |              | [yes](https://github.com/lightrush/framework-laptop-formula/pull/12) |
 | intel-audio-workaround       | yes          | yes          |                                                                      |
 | intel-ax210-workaround       | yes          | yes          |                                                                      |
 | intel-xe-tearing-workaround  |              | yes          |                                                                      |


### PR DESCRIPTION
no manual checks made - only based on the logged response from the formula.

```bash
grace@chesapeake:~/src/framework.formula$ sudo salt-call -l quiet --local --file-root="$(pwd)" state.apply framework-laptop
WARNING: CONFIG '/etc/salt' directory does not exist.
local:
----------
          ID: fingerprint-reader-pkgs-prebuilt-purged
    Function: pkg.purged
      Result: True
     Comment: All specified packages (matching specified versions) are already absent
     Started: 09:11:54.840934
    Duration: 13.541 ms
     Changes:   
----------
          ID: fingerprint-reader-pkgs-installed
    Function: pkg.latest
      Result: True
     Comment: The following packages were successfully installed/upgraded: fprintd-doc, gir1.2-fprint-2.0, libfprint-2-doc, libfprint-2-tod1 The following packages were already up-to-date: fprintd, libfprint-2-2, libpam-fprintd
     Started: 09:11:54.858653
    Duration: 3017.136 ms
     Changes:   
              ----------
              fprintd-doc:
                  ----------
                  new:
                      1.94.2-1
                  old:
              gir1.2-fprint-2.0:
                  ----------
                  new:
                      1:1.94.3+tod1-0ubuntu1
                  old:
              gir1.2-gusb-1.0:
                  ----------
                  new:
                      0.3.10-1
                  old:
              libfprint-2-doc:
                  ----------
                  new:
                      1:1.94.3+tod1-0ubuntu1
                  old:
              libfprint-2-tod1:
                  ----------
                  new:
                      1:1.94.3+tod1-0ubuntu1
                  old:
----------
          ID: fingerprint-reader-service-enabled
    Function: service.enabled
        Name: fprintd
      Result: True
     Comment: Service fprintd is already enabled, and is in the desired state
     Started: 09:11:57.882799
    Duration: 9.995 ms
     Changes:   
----------
          ID: fingerprint-reader-pam-auth-enabled
    Function: cmd.run
        Name: pam-auth-update --enable fprintd
      Result: True
     Comment: Command "pam-auth-update --enable fprintd" run
     Started: 09:11:57.893346
    Duration: 704.337 ms
     Changes:   
              ----------
              pid:
                  43086
              retcode:
                  0
              stderr:
              stdout:
----------
          ID: fingerprint-reader-delete-device-prints-util-installed
    Function: file.managed
        Name: /usr/local/bin/libfprint_delete_device_prints.py
      Result: True
     Comment: File /usr/local/bin/libfprint_delete_device_prints.py updated
     Started: 09:11:58.597887
    Duration: 36.014 ms
     Changes:   
              ----------
              diff:
                  New file
              mode:
                  0755
----------
          ID: fingerprint-reader-pam-config
    Function: file.replace
        Name: /etc/pam.d/common-auth
      Result: True
     Comment: No changes needed to be made
     Started: 09:11:58.635261
    Duration: 2.831 ms
     Changes:   
----------
          ID: framework-sec-trim-enable-udev-rule-installed
    Function: file.managed
        Name: /etc/udev/rules.d/10-framework-sec-trim.rules
      Result: True
     Comment: File /etc/udev/rules.d/10-framework-sec-trim.rules updated
     Started: 09:11:58.638157
    Duration: 11.489 ms
     Changes:   
              ----------
              diff:
                  New file
              mode:
                  0644
----------
          ID: grub_decrease_menu_timeout_config
    Function: file.replace
        Name: /etc/default/grub
      Result: True
     Comment: Changes were made
     Started: 09:11:58.649704
    Duration: 1.598 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -31,3 +31,4 @@
                   
                   # Uncomment to get a beep at grub start
                   #GRUB_INIT_TUNE="480 440 1"
                  +GRUB_RECORDFAIL_TIMEOUT=1
----------
          ID: grub_decrease_menu_timeout_grub_update
    Function: cmd.run
        Name: update-grub
      Result: True
     Comment: Command "update-grub" run
     Started: 09:11:58.651771
    Duration: 827.173 ms
     Changes:   
              ----------
              pid:
                  43094
              retcode:
                  0
              stderr:
                  Sourcing file `/etc/default/grub'
                  Sourcing file `/etc/default/grub.d/init-select.cfg'
                  Generating grub configuration file ...
                  Found linux image: /boot/vmlinuz-5.15.0-41-generic
                  Found initrd image: /boot/initrd.img-5.15.0-41-generic
                  Found linux image: /boot/vmlinuz-5.15.0-25-generic
                  Found initrd image: /boot/initrd.img-5.15.0-25-generic
                  Memtest86+ needs a 16-bit boot, that is not available on EFI, exiting
                  Warning: os-prober will not be executed to detect other bootable partitions.
                  Systems on them will not be added to the GRUB boot configuration.
                  Check GRUB_DISABLE_OS_PROBER documentation entry.
                  Adding boot menu entry for UEFI Firmware Settings ...
                  done
              stdout:
----------
          ID: intel_audio_workaround_modprobe_conf_installed
    Function: file.managed
        Name: /etc/modprobe.d/intel-audio-workaround.conf
      Result: True
     Comment: unless condition is true
     Started: 09:11:59.479168
    Duration: 608.437 ms
     Changes:   
----------
          ID: intel_audio_workaround_initramfs_updated
    Function: cmd.run
        Name: update-initramfs -u
      Result: True
     Comment: State was not run because none of the onchanges reqs changed
     Started: 09:12:00.087885
    Duration: 0.002 ms
     Changes:   
----------
          ID: intel_ax210_workaround_linux_generic_latest
    Function: pkg.latest
        Name: linux-generic-hwe-20.04
      Result: True
     Comment: The following packages were successfully installed/upgraded: linux-generic-hwe-20.04
     Started: 09:12:00.087917
    Duration: 2399.347 ms
     Changes:   
              ----------
              linux-generic-hwe-20.04:
                  ----------
                  new:
                      5.15.0.41.43
                  old:
----------
          ID: intel_ax210_workaround_service_dead
    Function: service.dead
        Name: intel-ax210-workaround
      Result: True
     Comment: The named service intel-ax210-workaround is not available
     Started: 09:12:02.492838
    Duration: 3.925 ms
     Changes:   
----------
          ID: intel_ax210_workaround_service_removed
    Function: file.absent
        Name: /etc/systemd/system/intel-ax210-workaround.service
      Result: True
     Comment: File /etc/systemd/system/intel-ax210-workaround.service is not present
     Started: 09:12:02.497728
    Duration: 0.318 ms
     Changes:   
----------
          ID: intel_ax210_workaround_service_removed
    Function: module.run
        Name: service.systemctl_reload
      Result: True
     Comment: State was not run because none of the onchanges reqs changed
     Started: 09:12:02.498552
    Duration: 0.002 ms
     Changes:   
----------
          ID: intel_ax210_workaround_firmware_restored
    Function: cmd.run
        Name: /bin/sh -c "mv -f /lib/firmware/iwlwifi-ty-a0-gf-a0.pnvm.renamed-by-salt /lib/firmware/iwlwifi-ty-a0-gf-a0.pnvm ; rmmod iwlmvm ; rmmod iwlwifi ; modprobe iwlwifi"
      Result: True
     Comment: unless condition is true
     Started: 09:12:02.498894
    Duration: 619.238 ms
     Changes:   
----------
          ID: intel_ax210_workaround_firmware_reinstalled
    Function: pkg.installed
        Name: linux-firmware
      Result: True
     Comment: unless condition is true
     Started: 09:12:03.118313
    Duration: 3.938 ms
     Changes:   
----------
          ID: intel_ax210_workaround_modprobe_conf_removed
    Function: file.absent
        Name: /etc/modprobe.d/intel-ax210-workaround.conf
      Result: True
     Comment: File /etc/modprobe.d/intel-ax210-workaround.conf is not present
     Started: 09:12:03.122320
    Duration: 0.363 ms
     Changes:   
----------
          ID: intel_ax210_workaround_initramfs_updated
    Function: cmd.run
        Name: update-initramfs -u
      Result: True
     Comment: State was not run because none of the onchanges reqs changed
     Started: 09:12:03.122932
    Duration: 0.002 ms
     Changes:   
----------
          ID: intel_xe_tearing_workaround_grub_old_config_line
    Function: file.replace
        Name: /etc/default/grub
      Result: True
     Comment: No changes needed to be made
     Started: 09:12:03.122958
    Duration: 1.0 ms
     Changes:   
----------
          ID: intel_xe_tearing_workaround_grub_old_config
    Function: file.replace
        Name: /etc/default/grub
      Result: True
     Comment: No changes needed to be made
     Started: 09:12:03.124182
    Duration: 0.904 ms
     Changes:   
----------
          ID: intel_xe_tearing_workaround_linux_generic_latest
    Function: pkg.latest
        Name: linux-generic-hwe-20.04
      Result: True
     Comment: Package linux-generic-hwe-20.04 is already up-to-date
     Started: 09:12:03.125141
    Duration: 1082.065 ms
     Changes:   
----------
          ID: intel_xe_tearing_workaround_grub_config
    Function: file.absent
        Name: /etc/default/grub.d/intel-xe-tearing-workaround.cfg
      Result: True
     Comment: File /etc/default/grub.d/intel-xe-tearing-workaround.cfg is not present
     Started: 09:12:04.207289
    Duration: 10.197 ms
     Changes:   
----------
          ID: intel_xe_tearing_workaround_grub_update
    Function: cmd.run
        Name: update-grub
      Result: True
     Comment: State was not run because none of the onchanges reqs changed
     Started: 09:12:04.218013
    Duration: 0.002 ms
     Changes:   
----------
          ID: mem_sleep_default_grub_config_removed
    Function: file.replace
        Name: /etc/default/grub
      Result: True
     Comment: No changes needed to be made
     Started: 09:12:04.218049
    Duration: 1.494 ms
     Changes:   
----------
          ID: mem_sleep_default_grub_config_removed_default
    Function: file.replace
        Name: /etc/default/grub
      Result: True
     Comment: No changes needed to be made
     Started: 09:12:04.219776
    Duration: 1.16 ms
     Changes:   
----------
          ID: mem_sleep_default_grub_config_file
    Function: file.managed
        Name: /etc/default/grub.d/mem-sleep-default.cfg
      Result: True
     Comment: File /etc/default/grub.d/mem-sleep-default.cfg updated
     Started: 09:12:04.221011
    Duration: 1.851 ms
     Changes:   
              ----------
              diff:
                  New file
----------
          ID: mem_sleep_default_grub_update
    Function: cmd.run
        Name: update-grub
      Result: True
     Comment: Command "update-grub" run
     Started: 09:12:04.223391
    Duration: 464.88 ms
     Changes:   
              ----------
              pid:
                  44274
              retcode:
                  0
              stderr:
                  Sourcing file `/etc/default/grub'
                  Sourcing file `/etc/default/grub.d/init-select.cfg'
                  Sourcing file `/etc/default/grub.d/mem-sleep-default.cfg'
                  Generating grub configuration file ...
                  Found linux image: /boot/vmlinuz-5.15.0-41-generic
                  Found initrd image: /boot/initrd.img-5.15.0-41-generic
                  Found linux image: /boot/vmlinuz-5.15.0-25-generic
                  Found initrd image: /boot/initrd.img-5.15.0-25-generic
                  Memtest86+ needs a 16-bit boot, that is not available on EFI, exiting
                  Warning: os-prober will not be executed to detect other bootable partitions.
                  Systems on them will not be added to the GRUB boot configuration.
                  Check GRUB_DISABLE_OS_PROBER documentation entry.
                  Adding boot menu entry for UEFI Firmware Settings ...
                  done
              stdout:
----------
          ID: tlp_service_dead
    Function: service.dead
        Name: tlp
      Result: True
     Comment: The named service tlp is not available
     Started: 09:12:04.688372
    Duration: 3.193 ms
     Changes:   
----------
          ID: tlp_package_purged
    Function: pkg.purged
        Name: tlp
      Result: True
     Comment: All specified packages are already absent
     Started: 09:12:04.691826
    Duration: 0.461 ms
     Changes:   
----------
          ID: touchpad-suspend-workaround
    Function: file.managed
        Name: /lib/systemd/system-sleep/touchpad-suspend-workaround
      Result: True
     Comment: File /lib/systemd/system-sleep/touchpad-suspend-workaround updated
     Started: 09:12:04.692351
    Duration: 22.361 ms
     Changes:   
              ----------
              diff:
                  New file
              mode:
                  0755
----------
          ID: grub-cleanup
    Function: cmd.run
        Name: sed -i "$(for line in $(grep -Pn '^GRUB_CMDLINE_LINUX_DEFAULT=.*$' /etc/default/grub | cut -d':' -f1 | tail -n +2); do echo -n ${line}d '; ' ; done)" /etc/default/grub
      Result: True
     Comment: unless condition is true
     Started: 09:12:04.714779
    Duration: 6.576 ms
     Changes:   
----------
          ID: post_resume_power_draw_workaround_grub_config_file
    Function: file.managed
        Name: /etc/default/grub.d/post-resume-power-draw-workaround.cfg
      Result: True
     Comment: File /etc/default/grub.d/post-resume-power-draw-workaround.cfg updated
     Started: 09:12:04.721427
    Duration: 2.107 ms
     Changes:   
              ----------
              diff:
                  New file
----------
          ID: post_resume_power_draw_workaround_grub_update
    Function: cmd.run
        Name: update-grub
      Result: True
     Comment: Command "update-grub" run
     Started: 09:12:04.723797
    Duration: 387.627 ms
     Changes:   
              ----------
              pid:
                  44850
              retcode:
                  0
              stderr:
                  Sourcing file `/etc/default/grub'
                  Sourcing file `/etc/default/grub.d/init-select.cfg'
                  Sourcing file `/etc/default/grub.d/mem-sleep-default.cfg'
                  Sourcing file `/etc/default/grub.d/post-resume-power-draw-workaround.cfg'
                  Generating grub configuration file ...
                  Found linux image: /boot/vmlinuz-5.15.0-41-generic
                  Found initrd image: /boot/initrd.img-5.15.0-41-generic
                  Found linux image: /boot/vmlinuz-5.15.0-25-generic
                  Found initrd image: /boot/initrd.img-5.15.0-25-generic
                  Memtest86+ needs a 16-bit boot, that is not available on EFI, exiting
                  Warning: os-prober will not be executed to detect other bootable partitions.
                  Systems on them will not be added to the GRUB boot configuration.
                  Check GRUB_DISABLE_OS_PROBER documentation entry.
                  Adding boot menu entry for UEFI Firmware Settings ...
                  done
              stdout:
----------
          ID: pulseaudio-bt-hires-codecs-pkgs-installed
    Function: pkg.latest
      Result: True
     Comment: The following packages were successfully installed/upgraded: gstreamer1.0-plugins-bad
     Started: 09:12:05.111594
    Duration: 9317.938 ms
     Changes:   
              ----------
              gsfonts:
                  ----------
                  new:
                      1:8.11+urwcyr1.0.7~pre44-4.5
                  old:
              gstreamer1.0-plugins-bad:
                  ----------
                  new:
                      1.20.1-1ubuntu2
                  old:
              i965-va-driver:
                  ----------
                  new:
                      2.4.1+dfsg1-1
                  old:
              imagemagick-6-common:
                  ----------
                  new:
                      8:6.9.11.60+dfsg-1.3build2
                  old:
              intel-media-va-driver:
                  ----------
                  new:
                      22.3.1+dfsg1-1ubuntu1
                  old:
              libaom3:
                  ----------
                  new:
                      3.3.0-1
                  old:
              libass9:
                  ----------
                  new:
                      1:0.15.2-1
                  old:
              libavcodec58:
                  ----------
                  new:
                      7:4.4.2-0ubuntu0.22.04.1
                  old:
              libavutil56:
                  ----------
                  new:
                      7:4.4.2-0ubuntu0.22.04.1
                  old:
              libbs2b0:
                  ----------
                  new:
                      3.1.0+dfsg-2.2build1
                  old:
              libchromaprint1:
                  ----------
                  new:
                      1.5.1-2
                  old:
              libcodec2-1.0:
                  ----------
                  new:
                      1.0.1-3
                  old:
              libdav1d5:
                  ----------
                  new:
                      0.9.2-1
                  old:
              libdc1394-25:
                  ----------
                  new:
                      2.2.6-4
                  old:
              libdca0:
                  ----------
                  new:
                      0.0.7-2
                  old:
              libde265-0:
                  ----------
                  new:
                      1.0.8-1
                  old:
              libdecor-0-0:
                  ----------
                  new:
                      0.1.0-3build1
                  old:
              libdecor-0-plugin-1-cairo:
                  ----------
                  new:
                      0.1.0-3build1
                  old:
              libdvdnav4:
                  ----------
                  new:
                      6.1.1-1
                  old:
              libdvdread8:
                  ----------
                  new:
                      6.1.2-1
                  old:
              libfaad2:
                  ----------
                  new:
                      2.10.0-2
                  old:
              libfftw3-double3:
                  ----------
                  new:
                      3.3.8-2ubuntu8
                  old:
              libflite1:
                  ----------
                  new:
                      2.2-3
                  old:
              libfluidsynth3:
                  ----------
                  new:
                      2.2.5-1
                  old:
              libfreeaptx0:
                  ----------
                  new:
                      0.1.1-1
                  old:
              libgme0:
                  ----------
                  new:
                      0.6.3-2
                  old:
              libgsm1:
                  ----------
                  new:
                      1.0.19-1
                  old:
              libgstreamer-plugins-bad1.0-0:
                  ----------
                  new:
                      1.20.1-1ubuntu2
                  old:
              libgupnp-igd-1.0-4:
                  ----------
                  new:
                      1.2.0-1build1
                  old:
              libheif1:
                  ----------
                  new:
                      1.12.0-2build1
                  old:
              libigdgmm12:
                  ----------
                  new:
                      22.1.2+ds1-1
                  old:
              libilmbase25:
                  ----------
                  new:
                      2.5.7-2
                  old:
              libinstpatch-1.0-2:
                  ----------
                  new:
                      1.1.6-1
                  old:
              libjxr-tools:
                  ----------
                  new:
                      1.2~git20170615.f752187-5
                  old:
              libjxr0:
                  ----------
                  new:
                      1.2~git20170615.f752187-5
                  old:
              libkate1:
                  ----------
                  new:
                      0.4.1-11build1
                  old:
              libldacbt-enc2:
                  ----------
                  new:
                      2.0.2.3+git20200429+ed310a0-4
                  old:
              liblilv-0-0:
                  ----------
                  new:
                      0.24.12-2
                  old:
              liblqr-1-0:
                  ----------
                  new:
                      0.4.2-2.1
                  old:
              libltc11:
                  ----------
                  new:
                      1.3.1-1
                  old:
              libmagickcore-6.q16-6:
                  ----------
                  new:
                      8:6.9.11.60+dfsg-1.3build2
                  old:
              libmagickcore-6.q16-6-extra:
                  ----------
                  new:
                      8:6.9.11.60+dfsg-1.3build2
                  old:
              libmagickwand-6.q16-6:
                  ----------
                  new:
                      8:6.9.11.60+dfsg-1.3build2
                  old:
              libmfx1:
                  ----------
                  new:
                      22.3.0-1
                  old:
              libmjpegutils-2.1-0:
                  ----------
                  new:
                      1:2.1.0+debian-6build1
                  old:
              libmodplug1:
                  ----------
                  new:
                      1:0.8.9.0-3
                  old:
              libmpcdec6:
                  ----------
                  new:
                      2:0.1~r495-2
                  old:
              libmpeg2encpp-2.1-0:
                  ----------
                  new:
                      1:2.1.0+debian-6build1
                  old:
              libmplex2-2.1-0:
                  ----------
                  new:
                      1:2.1.0+debian-6build1
                  old:
              libnice10:
                  ----------
                  new:
                      0.1.18-2
                  old:
              libopenal-data:
                  ----------
                  new:
                      1:1.19.1-2build3
                  old:
              libopenal1:
                  ----------
                  new:
                      1:1.19.1-2build3
                  old:
              libopenexr25:
                  ----------
                  new:
                      2.5.7-1
                  old:
              libopenh264-6:
                  ----------
                  new:
                      2.2.0+dfsg-2
                  old:
              libopenmpt0:
                  ----------
                  new:
                      0.6.1-1
                  old:
              libopenni2-0:
                  ----------
                  new:
                      2.2.0.33+dfsg-15
                  old:
              libqrencode4:
                  ----------
                  new:
                      4.1.1-1
                  old:
              libsdl2-2.0-0:
                  ----------
                  new:
                      2.0.20+dfsg-2ubuntu1.22.04.1
                  old:
              libserd-0-0:
                  ----------
                  new:
                      0.30.10-2
                  old:
              libshine3:
                  ----------
                  new:
                      3.1.1-2
                  old:
              libsnappy1v5:
                  ----------
                  new:
                      1.1.8-1build3
                  old:
              libsndio7.0:
                  ----------
                  new:
                      1.8.1-1.1
                  old:
              libsord-0-0:
                  ----------
                  new:
                      0.16.8-2
                  old:
              libsoundtouch1:
                  ----------
                  new:
                      2.3.1+ds1-1
                  old:
              libspandsp2:
                  ----------
                  new:
                      0.0.6+dfsg-2
                  old:
              libsratom-0-0:
                  ----------
                  new:
                      0.6.8-1
                  old:
              libsrt1.4-gnutls:
                  ----------
                  new:
                      1.4.4-4
                  old:
              libsrtp2-1:
                  ----------
                  new:
                      2.4.2-2
                  old:
              libswresample3:
                  ----------
                  new:
                      7:4.4.2-0ubuntu0.22.04.1
                  old:
              libva-drm2:
                  ----------
                  new:
                      2.14.0-1
                  old:
              libva-x11-2:
                  ----------
                  new:
                      2.14.0-1
                  old:
              libva2:
                  ----------
                  new:
                      2.14.0-1
                  old:
              libvdpau1:
                  ----------
                  new:
                      1.4-3build2
                  old:
              libvo-aacenc0:
                  ----------
                  new:
                      0.1.3-2
                  old:
              libvo-amrwbenc0:
                  ----------
                  new:
                      0.1.3-2
                  old:
              libwildmidi2:
                  ----------
                  new:
                      0.4.3-1
                  old:
              libx264-163:
                  ----------
                  new:
                      2:0.163.3060+git5db6aa6-2build1
                  old:
              libx265-199:
                  ----------
                  new:
                      3.5-2
                  old:
              libxvidcore4:
                  ----------
                  new:
                      2:1.3.7-1
                  old:
              libzbar0:
                  ----------
                  new:
                      0.23.92-4build2
                  old:
              libzvbi-common:
                  ----------
                  new:
                      0.2.35-19
                  old:
              libzvbi0:
                  ----------
                  new:
                      0.2.35-19
                  old:
              libzxingcore1:
                  ----------
                  new:
                      1.2.0-1
                  old:
              mesa-va-drivers:
                  ----------
                  new:
                      22.0.1-1ubuntu2.1
                  old:
              mesa-vdpau-drivers:
                  ----------
                  new:
                      22.0.1-1ubuntu2.1
                  old:
              ocl-icd-libopencl1:
                  ----------
                  new:
                      2.2.14-3
                  old:
              timgm6mb-soundfont:
                  ----------
                  new:
                      1.3-5
                  old:
              va-driver-all:
                  ----------
                  new:
                      2.14.0-1
                  old:
              vdpau-driver-all:
                  ----------
                  new:
                      1.4-3build2
                  old:

Summary for local
-------------
Succeeded: 35 (changed=13)
Failed:     0
-------------
Total states run:     35
Total run time:   19.564 s
```